### PR TITLE
Support nlohmann_json 3.12

### DIFF
--- a/aruco/apps/positioner.cpp
+++ b/aruco/apps/positioner.cpp
@@ -89,11 +89,19 @@ struct CameraConfiguration {
     affine_rotation::AffineRotation camera_to_drone{};
 };
 
-// Mark to_json as potentially unused to make clang happy. This is ugly, but it
-// works.
-[[maybe_unused]] NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
-    CameraConfiguration, focal_length_x, focal_length_y, optical_center_x,
-    optical_center_y, distortion_coefficients, camera_to_drone);
+// clang doesn't like the fact that the generated to_json is unused when using
+// nlohmann_json 3.11.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif // __clang__
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CameraConfiguration, focal_length_x,
+                                   focal_length_y, optical_center_x,
+                                   optical_center_y, distortion_coefficients,
+                                   camera_to_drone);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
 
 /// Returns true if the user wants to exit the application. Handles pausing and
 /// blocks until the user unpauses.

--- a/aruco/src/world.cpp
+++ b/aruco/src/world.cpp
@@ -33,10 +33,17 @@ struct PlacementJson {
     std::uint32_t id{};
     affine_rotation::AffineRotation board_to_world{};
 };
-// Mark to_json as potentially unused to make clang happy. This is ugly, but it
-// works.
-[[maybe_unused]] NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PlacementJson, id,
-                                                    board_to_world);
+
+// clang doesn't like the fact that the generated to_json is unused when using
+// nlohmann_json 3.11.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif // __clang__
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PlacementJson, id, board_to_world);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
 
 } // namespace
 


### PR DESCRIPTION
`nlohmann_json` 3.12 changes the way `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE` is defined so that the old hack gets broken. The warning is no longer emitted on the new version, but our container images are still stuck on 3.11, so redesign the workaround to support both.